### PR TITLE
Add missing hex dependency

### DIFF
--- a/curve25519-dalek/Cargo.toml
+++ b/curve25519-dalek/Cargo.toml
@@ -32,7 +32,6 @@ features = ["serde", "rand_core", "digest", "legacy_compatibility"]
 [dev-dependencies]
 sha2 = { version = "0.10", default-features = false }
 bincode = "1"
-hex = "0.4.2"
 rand = "0.8"
 rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 
@@ -48,6 +47,7 @@ required-features = ["alloc", "rand_core"]
 [dependencies]
 cfg-if = "1"
 group = { version = "0.13", default-features = false, optional = true }
+hex = "0.4.2"
 rand_core = { version = "0.6.4", default-features = false, optional = true }
 digest = { version = "0.10", default-features = false, optional = true }
 subtle = { version = "2.3.0", default-features = false }


### PR DESCRIPTION
This PR fixes the compilation issue on the guest due to a missing `hex` dependency used in:
https://github.com/risc0/curve25519-dalek/blob/987c3b29e828793f9fed9ada7ff931df32a6ef69/curve25519-dalek/src/backend/serial/risc0/field.rs#L41-L49



 